### PR TITLE
fix(sparse): hierarchical pattern load balancer was a silent no-op

### DIFF
--- a/src/dilated_attention_pytorch/sparse/sparse_pattern_generator.py
+++ b/src/dilated_attention_pytorch/sparse/sparse_pattern_generator.py
@@ -255,18 +255,23 @@ class HierarchicalSparsePatternGenerator:
         Returns:
             Adjusted patterns
         """
-        if not self.load_stats["computation_times"]:
-            return patterns  # No history for balancing yet
+        times = self.load_stats["computation_times"]
+        if len(times) < 2:
+            return patterns  # need at least a short history to detect drift
 
-        # Calculate load imbalance
-        recent_times = self.load_stats["computation_times"][
-            -10:
-        ]  # Last 10 measurements
-        avg_time = sum(recent_times) / len(recent_times)
+        # Compare this rank's RECENT load window against its longer-term
+        # baseline. A rank trending slower than its own baseline is locally
+        # overloaded and sheds work (more sparsity); trending faster, it takes
+        # on more. (Per-rank adaptive regulation from local history only — true
+        # cross-rank balancing via cost-based block->rank assignment is a
+        # separate L3 concern and needs a collective the generator lacks.)
+        recent = times[-10:]  # last 10 measurements
+        recent_avg = sum(recent) / len(recent)
+        baseline_avg = sum(times) / len(times)
 
-        # Check if this rank is overloaded
-        is_overloaded = avg_time > (1 + self.config.load_balance_threshold) * avg_time
-        is_underloaded = avg_time < (1 - self.config.load_balance_threshold) * avg_time
+        thr = self.config.load_balance_threshold
+        is_overloaded = recent_avg > (1 + thr) * baseline_avg
+        is_underloaded = recent_avg < (1 - thr) * baseline_avg
 
         if is_overloaded:
             # Reduce computation by increasing sparsity

--- a/tests/sparse/test_pattern_load_balancing.py
+++ b/tests/sparse/test_pattern_load_balancing.py
@@ -1,0 +1,85 @@
+"""Regression tests for `HierarchicalSparsePatternGenerator` load balancing.
+
+Guards the bug where `_apply_load_balancing` compared `avg_time` to a multiple of
+*itself* (`avg_time > (1 + thr) * avg_time`), so the over/under-load branches were
+dead code and the balancer was a silent no-op. The fix compares the recent load
+window against the rank's longer-term baseline; these tests assert each branch fires
+and produces the right direction of sparsity adjustment.
+"""
+
+import torch
+
+from dilated_attention_pytorch.sparse.distributed_sparse_config import (
+    DistributedSparseConfig,
+)
+from dilated_attention_pytorch.sparse.sparse_pattern_generator import (
+    HierarchicalSparsePatternGenerator,
+)
+
+
+def _generator() -> HierarchicalSparsePatternGenerator:
+    # All-default config; node-size detection falls back to min(8, world_size)
+    # with no distributed init required.
+    return HierarchicalSparsePatternGenerator(
+        DistributedSparseConfig(), world_size=8, rank=0
+    )
+
+
+def _half_dense_patterns() -> dict[str, torch.Tensor]:
+    # ~50% density so there is room to both add and remove connections.
+    torch.manual_seed(0)
+    pat = torch.rand(2, 8, 8) < 0.5
+    return {"local": pat.clone()}
+
+
+def _density(patterns: dict[str, torch.Tensor]) -> float:
+    return float(patterns["local"].float().mean())
+
+
+def _push(gen: HierarchicalSparsePatternGenerator, times: list[float]) -> None:
+    for t in times:
+        gen.update_load_stats(
+            computation_time=t, communication_volume=0, memory_usage=0
+        )
+
+
+def test_overloaded_rank_sheds_work() -> None:
+    """Recent load >> baseline → overloaded → sparsity increases (density drops)."""
+    gen = _generator()
+    _push(gen, [1.0] * 20 + [3.0] * 10)  # recent 10 high vs baseline ~1.67
+    patterns = _half_dense_patterns()
+    before = _density(patterns)
+    after = _density(gen._apply_load_balancing(patterns, num_blocks=8))
+    assert after < before, f"overloaded rank should shed work: {after} !< {before}"
+
+
+def test_underloaded_rank_takes_more_work() -> None:
+    """Recent load << baseline → underloaded → sparsity decreases (density rises)."""
+    gen = _generator()
+    _push(gen, [3.0] * 20 + [1.0] * 10)  # recent 10 low vs baseline ~2.33
+    patterns = _half_dense_patterns()
+    before = _density(patterns)
+    after = _density(gen._apply_load_balancing(patterns, num_blocks=8))
+    assert after > before, (
+        f"underloaded rank should take more work: {after} !> {before}"
+    )
+
+
+def test_balanced_rank_is_unchanged() -> None:
+    """Recent load == baseline → neither branch fires → pattern untouched."""
+    gen = _generator()
+    _push(gen, [1.0] * 30)
+    patterns = _half_dense_patterns()
+    before = _density(patterns)
+    after = _density(gen._apply_load_balancing(patterns, num_blocks=8))
+    assert after == before, f"balanced rank should be unchanged: {after} != {before}"
+
+
+def test_no_history_is_noop() -> None:
+    """Too little history (< 2 samples) → no adjustment, no crash."""
+    gen = _generator()
+    patterns = _half_dense_patterns()
+    before = _density(patterns)
+    assert _density(gen._apply_load_balancing(patterns, num_blocks=8)) == before
+    _push(gen, [1.0])  # single sample still below the 2-sample floor
+    assert _density(gen._apply_load_balancing(patterns, num_blocks=8)) == before


### PR DESCRIPTION
## Bug
`HierarchicalSparsePatternGenerator._apply_load_balancing` (`sparse/sparse_pattern_generator.py`) compared `avg_time` to a multiple of **itself**:
```python
is_overloaded  = avg_time > (1 + thr) * avg_time   # 1 > 1+thr  → always False (thr>0)
is_underloaded = avg_time < (1 - thr) * avg_time   # 1 < 1-thr  → always False (thr>0)
```
So both branches were dead code and the over/under-load sparsity adjustment **never ran** — the balancer was a silent no-op. (Surfaced during the L3 ring-hierarchy design review: §5.1's "reuse the generator's load balancing" was relying on this.)

## Fix
Compare the **recent load window** (last 10) against the rank's **longer-term baseline** (full-history mean). A rank trending slower than its own baseline sheds work (more sparsity); one trending faster takes on more. This is per-rank adaptive regulation from local history only — true **cross-rank** balancing (cost-based block→rank assignment) stays a separate L3 work item (it needs a collective the generator doesn't have), now noted in the comment.

## Test
`tests/sparse/test_pattern_load_balancing.py` — asserts each branch now fires in the right direction (overloaded → density drops, underloaded → density rises), the balanced case is unchanged, and <2 samples is a safe no-op. 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)